### PR TITLE
s/bad/wrong/

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -705,7 +705,7 @@ only the specs you need to test blazing fast without stopping your flow.
 Do not use should when describing your tests. Use the third person in the present tense.
 </p>
 
-<p class="bad">bad</p>
+<p class="wrong">bad</p>
 
 <div>
 <pre><code class="ruby">it 'should not change timings' do


### PR DESCRIPTION
Corrects class name in #should example.
