### PR TITLE
Prefer FactoryGirl.create_list

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -486,7 +486,7 @@ Also, if you think you need dozens of records, you are probably wrong.
 <div>
 <pre><code class="ruby">describe "User"
   describe ".top" do
-    before { 3.times { Factory(:user) } }
+    before { FactoryGirl.create_list(:user, 3) }
     it { User.top(2).should have(2).item }
   end
 end


### PR DESCRIPTION
`Factory()` syntax is gone, anyway.
