### PR TITLE
Mention should_not and should_clean in "Don't use should"

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -771,6 +771,9 @@ end
 </code></pre>
 </div>
 
+See <a href="https://github.com/should-not/should_not">the should_not gem</a> for a way to enforce this in RSpec
+and <a href="https://github.com/siyelo/should_clean">the should_clean</a> gem for a way to clean up existing RSpec examples that begin with "should."
+
 <p>
 <a href="https://github.com/andreareginato/betterspecs/issues/15">Discuss this guideline &rarr;</a>
 </p>


### PR DESCRIPTION
[should_not](https://github.com/should-not/should_not) and [should_clean](https://github.com/siyelo/should_clean) are tools that share the opinion of not starting specs with should.

/cc @glennr
