### PR TITLE
Remove "should" from test description.

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -360,7 +360,7 @@ RSpec has also the ability to use a named subject.
 
 <div>
 <pre><code class="ruby">subject(:hero) { Hero.first }
-it "should be equipped with a sword" do
+it "carries a sword" do
   hero.equipment.should include "sword"
 end
 </code></pre>


### PR DESCRIPTION
This is consistent with the move away from 'should'. Leave the test code using `should` instead of `expect` to be consistent with the other test code blocks.
