### PR TITLE
Remove duplicate line in "Use let and let!"

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -428,7 +428,6 @@ Use <code>let</code> to initialize actions that are lazy loaded to test your spe
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-context 'when updates a not existing property value' do
   let(:properties) { { id: Settings.resource_id, value: 'on'} }
 
   def update


### PR DESCRIPTION
Removes duplicate:
context 'when updates a not existing property value' do
