### PR TITLE
Correct "wrong" version for 'Do not use should' comparison

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -779,7 +779,7 @@ syntax.
 
 <div>
 <pre><code class="ruby">it 'should not change timings' do
-  expect(consumption.occur_at).to == valid.occur_at
+  consumption.occur_at.should == valid.occur_at
 end
 </code></pre>
 </div>


### PR DESCRIPTION
The "wrong" example should use 'should' and not expect'
