### PR TITLE
Fix zh_cn typo

### DIFF
--- a/content/zh_cn.html
+++ b/content/zh_cn.html
@@ -750,7 +750,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  consumption.occur_at.should == valid.occur_at
+  expect(consumption.occur_at).to == valid.occur_at
 end
 </code></pre>
 </div>


### PR DESCRIPTION
Fixed words in follow:
- rspec -> RSpec
- bdd -< BDD
- capybara -> Capybara
- guard -> Guard
- factorygirl -> FactoryGirl
