### PR TITLE
Make it more clear that should one line syntax is still good to use

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -357,6 +357,16 @@ end</code></pre>
 </div>
 <p>On old projects you can use the <a href="https://github.com/yujinakayama/transpec">transpec</a> to convert to the new syntax.</p>
 <p>On one line expectations or with implicit subject we still use the should syntax, since is no change here on new syntax, <a href="http://stackoverflow.com/a/12266147/2254521">more info here</a></p>
+
+<p class="correct">good</p>
+
+<div>
+<pre><code class="ruby">context 'when not valid' do
+  it { should respond_with 422 } #this is still good!
+end
+</code></pre>
+</div>
+
 <p>More about the new Rspec expectation syntax can be found <a href="http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax">here</a> and <a href="http://myronmars.to/n/dev-blog/2013/07/the-plan-for-rspec-3#what_about_the_old_expectationmock_syntax">here</a>.</p>
 
 <p>


### PR DESCRIPTION
Do not trust people to read three lines of text after the last code block in a section. Include this so that it will stand out that this is still supported. I skimmed over it and got confused why other sections were still using should. I didn't find the explanation about this until I went to the github discussion for the section. Don't trust people to notice stuff at the bottom of these sections.
