### PR TITLE
Fix sentence to for 'let' article

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -426,7 +426,7 @@ Learn more about <a href="https://www.relishapp.com/rspec/rspec-core/v/2-11/docs
 When you have to assign a variable instead of using a <code>before</code> block to create
 an instance variable, use <code>let</code>. Using <code>let</code> the variable lazy loads
 only when it is used the first time in the test and get cached until that specific test is
-finished. A really good and deep description of what <code>let</code> can be found in this
+finished. A really good and deep description of what <code>let</code> does can be found in this
 <a href="http://stackoverflow.com/questions/5359558/when-to-use-rspec-let/5359979#5359979">stackoverflow answer</a>.
 </p>
 


### PR DESCRIPTION
Sentence wasn't correct as it missed the word 'does'.
