### PR TITLE
fixing translation to some forgotten english words

### DIFF
--- a/content/br.html
+++ b/content/br.html
@@ -242,7 +242,7 @@ it { should assign_to(:resource) }
 
 <p>
 
-<p class="correct">Good (não isolado)</p>
+<p class="correct">bom (não isolado)</p>
 
 <div>
 <pre><code class="ruby">it 'creates a resource' do
@@ -354,10 +354,10 @@ it { should match /it was born in Billville/ }
 </div>
 
 <p>
-  RSpec também tem a habilidade de usar um subjeito com nome.
+  RSpec também tem a habilidade de usar um sujeito com nome.
 </p>
 
-<p class="correct">Good</p>
+<p class="correct">bom</p>
 
 <div>
 <pre><code class="ruby">subject(:hero) { Hero.first }


### PR DESCRIPTION
just some forgotten english words:
- "good" translated to "bom", just following the pattern.
- "subjeito" is a wrong translation of "subject", the right one is "sujeito".
