### PR TITLE
Remove unrelated code snippet

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -991,16 +991,6 @@ group :development, :test do
 <p class="correct">good</p>
 
 <div>
-<pre><code class="ruby"># Guardfile
-guard 'rspec' do
-  # ...
-end
-</code></pre>
-</div>
-
-<p class="correct">good</p>
-
-<div>
 <pre><code class="ruby"># .rspec
 --drb
 --format Fuubar


### PR DESCRIPTION
The guideline is regarding formatters and has nothing to do with Guard.
