### PR TITLE
Using RSpec one-liner syntax

### DIFF
--- a/content/br.html
+++ b/content/br.html
@@ -138,10 +138,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>

--- a/content/es.html
+++ b/content/es.html
@@ -138,10 +138,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>

--- a/content/fr.html
+++ b/content/fr.html
@@ -133,10 +133,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>

--- a/content/index.html
+++ b/content/index.html
@@ -138,10 +138,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>

--- a/content/jp.html
+++ b/content/jp.html
@@ -153,10 +153,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>

--- a/content/ko.html
+++ b/content/ko.html
@@ -153,10 +153,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>

--- a/content/ru.html
+++ b/content/ru.html
@@ -139,10 +139,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>

--- a/content/zh_cn.html
+++ b/content/zh_cn.html
@@ -133,10 +133,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>
@@ -1110,4 +1110,3 @@ end
   allowtransparency="true" frameborder="0" scrolling="0" width="300px" height="30px"></iframe>
 
 </div>
-

--- a/content/zh_tw.html
+++ b/content/zh_tw.html
@@ -161,10 +161,10 @@ end
 
 <div>
 <pre><code class="ruby">context 'when logged in' do
-  it { should respond_with 200 }
+  it { is_expected.to respond_with 200 }
 end
 context 'when logged out' do
-  it { should respond_with 401 }
+  it { is_expected.to respond_with 401 }
 end
 </code></pre>
 </div>


### PR DESCRIPTION
Replace should for is_expected as pointed for @ZenCocoon https://github.com/andreareginato/betterspecs/issues/3#issuecomment-40067469 the one-liner syntax is a prefered way.
