### PR TITLE
Corrected good example not to use should

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -178,7 +178,7 @@ you should split it using a context.
 
 <div>
 <pre><code class="ruby">context 'when not valid' do
-  it { should respond_with 422 }
+  it { is_expected.to respond_with 422 }
 end
 </code></pre>
 </div>


### PR DESCRIPTION
I was confused that one of your "good" examples uses `should` instead of `is_expected.to` even though a later [recommendation](http://betterspecs.org/#should) discourages that.

I think this also fixes #83.

Thanks for the great site. It's very helpful.
