### PR TITLE
Removes dead link to missing Help section

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -30,7 +30,6 @@ title: 'Better Specs'
 <li><a href="#styleguide">Styleguide</a></li>
 <li><a href="#improving">Improving Better Specs</a></li>
 <li><a href="#credits">Credits</a></li>
-<li><a href="#help">Help us</a></li>
 <% end %>
 
 <div class="content">


### PR DESCRIPTION
Hey Andrea,
I wonder why the Help-Sections is missing in the english translation. In the french, russian and spanish translation there is a PayPal link.

This PR just removes the link which still targets the missing section but instead you may want to recover the help section? :grin: