### PR TITLE
Fix typo

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <title>Better Specs { rspec guidelines with ruby }</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="description" content="Better Specs tries to fill the miss of testing guidelines by collecting most of the best practices developers has been learning the hard way through years of experience">
+    <meta name="description" content="Better Specs tries to fill the gap of testing guidelines by collecting most of the best practices developers has been learning the hard way through years of experience">
 
     <link href="/stylesheets/bootstrap.min.css" media="screen" rel="stylesheet" type="text/css" />
     <link href="/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
- `fill the miss` is nonsensical. At very least I've never heard this phrase.
- `fix the mess` is the most logical, based on intent. Seems a bit harsh, perhaps?