### PR TITLE
Reformat code examples to be within 80 characters

### DIFF
--- a/content/br.html
+++ b/content/br.html
@@ -493,7 +493,10 @@ Saiba mais sobre <a href="https://www.relishapp.com/rspec/rspec-core/v/2-11/docs
 <div>
 <pre><code class="ruby"># simulate a not found resource
 context "when not found" do
-  before { allow(Resource).to receive(:where).with(created_from: params[:id]).and_return(false) }
+  before do
+    allow(Resource).to receive(:where).with(created_from: params[:id])
+      .and_return(false)
+  end
   it { should respond_with 404 }
 end
 </code></pre>

--- a/content/es.html
+++ b/content/es.html
@@ -525,7 +525,10 @@ Probar casos reales es útil cuando se actualiza el flujo de la aplicación.
 <div>
 <pre><code class="ruby"># simulate a not found resource
 context "when not found" do
-  before { allow(Resource).to receive(:where).with(created_from: params[:id]).and_return(false) }
+  before do
+    allow(Resource).to receive(:where).with(created_from: params[:id])
+      .and_return(false)
+  end
   it { should respond_with 404 }
 end
 </code></pre>

--- a/content/fr.html
+++ b/content/fr.html
@@ -509,7 +509,10 @@ Ne pas (trop) utiliser les «mocks» et tester le comportement réel quand c'est
 <div>
 <pre><code class="ruby"># simulate a not found resource
 context "when not found" do
-  before { allow(Resource).to receive(:where).with(created_from: params[:id]).and_return(false) }
+  before do
+    allow(Resource).to receive(:where).with(created_from: params[:id])
+      .and_return(false)
+  end
   it { should respond_with 404 }
 end
 </code></pre>

--- a/content/index.html
+++ b/content/index.html
@@ -546,7 +546,10 @@ Testing real cases are useful when updating your application flow.
 <div>
 <pre><code class="ruby"># simulate a not found resource
 context "when not found" do
-  before { allow(Resource).to receive(:where).with(created_from: params[:id]).and_return(false) }
+  before do
+    allow(Resource).to receive(:where).with(created_from: params[:id])
+      .and_return(false)
+  end
   it { is_expected.to respond_with 404 }
 end
 </code></pre>

--- a/content/jp.html
+++ b/content/jp.html
@@ -609,7 +609,10 @@ Testing real cases are useful when updating your application flow.
 <div>
 <pre><code class="ruby"># simulate a not found resource
 context "when not found" do
-  before { allow(Resource).to receive(:where).with(created_from: params[:id]).and_return(false) }
+  before do
+    allow(Resource).to receive(:where).with(created_from: params[:id])
+      .and_return(false)
+  end
   it { should respond_with 404 }
 end
 </code></pre>

--- a/content/ko.html
+++ b/content/ko.html
@@ -526,7 +526,10 @@ end
 <div>
 <pre><code class="ruby"># simulate a not found resource
 context "when not found" do
-  before { allow(Resource).to receive(:where).with(created_from: params[:id]).and_return(false) }
+  before do
+    allow(Resource).to receive(:where).with(created_from: params[:id])
+      .and_return(false)
+  end
   it { is_expected.to respond_with 404 }
 end
 </code></pre>

--- a/content/ru.html
+++ b/content/ru.html
@@ -491,7 +491,10 @@ end
 <div>
 <pre><code class="ruby"># simulate a not found resource
 context "when not found" do
-  before { allow(Resource).to receive(:where).with(created_from: params[:id]).and_return(false) }
+  before do
+    allow(Resource).to receive(:where).with(created_from: params[:id])
+      .and_return(false)
+  end
   it { should respond_with 404 }
 end
 </code></pre>


### PR DESCRIPTION
Fix line length overflow in code examples. Stick to less than 80 chars per line. 

![selection_082](https://cloud.githubusercontent.com/assets/123158/6773293/52388444-d14a-11e4-8eee-4a6bd7b04b27.png)
