### PR TITLE
Use correct neither…nor construction

### DIFF
--- a/index.html
+++ b/index.html
@@ -601,7 +601,7 @@ user = FactoryGirl.create :user
 </div>
 
 <p>
-One important note. When talking about unit tests the best practice would be to use neither fixtures or factories. Put as much of your domain logic in libraries that can be tested without needing complex, time consuming setup with either factories or fixtures. Read more in
+One important note. When talking about unit tests the best practice would be to use neither fixtures nor factories. Put as much of your domain logic in libraries that can be tested without needing complex, time consuming setup with either factories or fixtures. Read more in
 <a href="http://blog.steveklabnik.com/posts/2012-07-14-why-i-don-t-like-factory_girl">this article</a>.
 </p>
 


### PR DESCRIPTION
"neither fixtures or factories" is grammatically incorrect. This PR changes the clause to "neither fixtures nor factories".

An alternative, but more intrusive, fix would be to change the whole sentence to "When talking about unit tests the best practice is to avoid fixtures and factories entirely."

http://thewritepractice.com/how-to-use-either-neither-or-and-nor-correctly/
