### PR TITLE
Prefer eq matcher than equal

### DIFF
--- a/br.html
+++ b/br.html
@@ -769,7 +769,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 </code></pre>
 </div>

--- a/fr.html
+++ b/fr.html
@@ -422,7 +422,7 @@ Lors de l'assignation d'une variable, vous pouvez à la place de créer un bloc 
   before { @type     = Type.find @resource.type_id }
 
   it 'sets the type_id field' do
-    expect(@resource.type_id).to equal(@type.id)
+    expect(@resource.type_id).to eq(@type.id)
   end
 end
 </code></pre>
@@ -436,7 +436,7 @@ end
   let(:type)     { Type.find resource.type_id }
 
   it 'sets the type_id field' do
-    expect(resource.type_id).to equal(type.id)
+    expect(resource.type_id).to eq(type.id)
   end
 end
 </code></pre>
@@ -754,7 +754,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 </code></pre>
 </div>

--- a/index.html
+++ b/index.html
@@ -433,7 +433,7 @@ describe '#type_id' do
   before { @type     = Type.find @resource.type_id }
 
   it 'sets the type_id field' do
-    expect(@resource.type_id).to equal(@type.id)
+    expect(@resource.type_id).to eq(@type.id)
   end
 end
 {% endhighlight %}
@@ -448,7 +448,7 @@ describe '#type_id' do
   let(:type)     { Type.find resource.type_id }
 
   it 'sets the type_id field' do
-    expect(resource.type_id).to equal(type.id)
+    expect(resource.type_id).to eq(type.id)
   end
 end
 {% endhighlight %}
@@ -769,7 +769,7 @@ end
 
 {% highlight ruby %}
 it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 {% endhighlight %}
 </div>

--- a/jp.html
+++ b/jp.html
@@ -500,7 +500,7 @@ finished. A really good and deep description of what <code>let</code> can be fou
   before { @type     = Type.find @resource.type_id }
 
   it 'sets the type_id field' do
-    expect(@resource.type_id).to equal(@type.id)
+    expect(@resource.type_id).to eq(@type.id)
   end
 end
 </code></pre>
@@ -514,7 +514,7 @@ end
   let(:type)     { Type.find resource.type_id }
 
   it 'sets the type_id field' do
-    expect(resource.type_id).to equal(type.id)
+    expect(resource.type_id).to eq(type.id)
   end
 end
 </code></pre>
@@ -926,7 +926,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 </code></pre>
 </div>

--- a/ko.html
+++ b/ko.html
@@ -437,7 +437,7 @@ end
   before { @type     = Type.find @resource.type_id }
 
   it 'sets the type_id field' do
-    expect(@resource.type_id).to equal(@type.id)
+    expect(@resource.type_id).to eq(@type.id)
   end
 end
 </code></pre>
@@ -451,7 +451,7 @@ end
   let(:type)     { Type.find resource.type_id }
 
   it 'sets the type_id field' do
-    expect(resource.type_id).to equal(type.id)
+    expect(resource.type_id).to eq(type.id)
   end
 end
 </code></pre>
@@ -770,7 +770,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 </code></pre>
 </div>

--- a/ru.html
+++ b/ru.html
@@ -399,7 +399,7 @@ end
   before { @type     = Type.find @resource.type_id }
 
   it 'sets the type_id field' do
-    expect(@resource.type_id).to equal(@type.id)
+    expect(@resource.type_id).to eq(@type.id)
   end
 end
 </code></pre>
@@ -413,7 +413,7 @@ end
   let(:type)     { Type.find resource.type_id }
 
   it 'sets the type_id field' do
-    expect(resource.type_id).to equal(type.id)
+    expect(resource.type_id).to eq(type.id)
   end
 end
 </code></pre>
@@ -760,7 +760,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 </code></pre>
 </div>

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -390,7 +390,7 @@ lazy load 的机制，只有在第一次用到的时候才会加载，然后就�
   before { @type     = type.find @resource.type_id }
 
   it 'sets the type_id field' do
-    expect(@resource.type_id).to equal(@type.id)
+    expect(@resource.type_id).to eq(@type.id)
   end
 end
 </code></pre>
@@ -404,7 +404,7 @@ end
   let(:type)     { type.find resource.type_id }
 
   it 'sets the type_id field' do
-    expect(resource.type_id).to equal(type.id)
+    expect(resource.type_id).to eq(type.id)
   end
 end
 </code></pre>
@@ -750,7 +750,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 </code></pre>
 </div>

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -474,7 +474,7 @@ finished. A really good and deep description of what <code>let</code> can be fou
   before { @type     = Type.find @resource.type_id }
 
   it 'sets the type_id field' do
-    @resource.type_id.should equal(@type.id)
+    @resource.type_id.should eq(@type.id)
   end
 end
 </code></pre>
@@ -488,7 +488,7 @@ end
   let(:type)     { Type.find resource.type_id }
 
   it 'sets the type_id field' do
-    resource.type_id.should equal(type.id)
+    resource.type_id.should eq(type.id)
   end
 end
 </code></pre>
@@ -902,7 +902,7 @@ end
 
 <div>
 <pre><code class="ruby">it 'does not change timings' do
-  expect(consumption.occur_at).to equal(valid.occur_at)
+  expect(consumption.occur_at).to eq(valid.occur_at)
 end
 </code></pre>
 </div>


### PR DESCRIPTION
Comparing with `equal?` looks not intended for the purpose.

```ruby
Time.at(42).equal? Time.at(42)
#=> false
```