### PR TITLE
add note to use gh-pages not master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ RSpec Best Practices website is tested against MRI 1.9.3.
 
 Fork the repo on github and send a pull requests with topic branches.
 
+Please remember to fork from `gh-pages` and not `master`.
+
 ## Feedback
 
 Use the [issue tracker](https://github.com/andreareginato/betterspecs/issues) for bugs.


### PR DESCRIPTION
updating `README.md` on master to let people know they should be forking / merging to `gh-pages`.

The contributing guide does say this, but `master` is so ingrained in my brain that I was working off the wrong version. Hope to help others not make the same mistake.

Thanks for the great resource