### PR TITLE
Separate setup: Adds a section on separating setup

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -10,6 +10,7 @@ en:
     let: Use let and let!
     mock: Mock or not to mock
     data: Create the data you need
+    separate: Separate setup
     factories: Use factories
     matchers: Easy to use matchers
     shared: Shared examples
@@ -133,6 +134,20 @@ en:
       ones), test suites can be heavy to run. To solve this problem, it's \
       important not to load more data than needed. Also, if you think you need \
       dozens of records, you are probably wrong."
+  separate:
+    title: Separate setup from tests
+    body:
+      first: "Keep the body of tests focused on the actions under test. Move \
+        setup steps to a <code>before</code>, <code>let</code>, or \
+        <code>subject</code>."
+      second: "This structure highlights what action is being tested, and \
+        makes it clear which parts are only necessary for setup. In this \
+        example we're communicating that all the tests describing a User will \
+        need <code>User.create</code>, but only tests of the \
+        <code>#fiddle</code> method need to setup a mock Fiddle.
+
+        Related to this, when a context describes a new variation, put the \
+        setup which creates that variation right below it."
   factories:
     title: Use factories and not fixtures
     body:

--- a/_includes/index.html
+++ b/_includes/index.html
@@ -18,6 +18,7 @@ layout: default
       <li class="menu__item"><a class="menu__link" href="#let">{{ 'menu.let' | translate }}</a></li>
       <li class="menu__item"><a class="menu__link" href="#mock">{{ 'menu.mock' | translate }}</a></li>
       <li class="menu__item"><a class="menu__link" href="#data">{{ 'menu.data' | translate }}</a></li>
+      <li class="menu__item"><a class="menu__link" href="#separate">{{ 'menu.separate' | translate }}</a></li>
       <li class="menu__item"><a class="menu__link" href="#factories">{{ 'menu.factories' | translate }}</a></li>
       <li class="menu__item"><a class="menu__link" href="#matchers">{{ 'menu.matchers' | translate }}</a></li>
       <li class="menu__item"><a class="menu__link" href="#shared">{{ 'menu.shared' | translate }}</a></li>
@@ -488,6 +489,66 @@ end
 
     <p>
       <a href="https://github.com/andreareginato/betterspecs/issues/10">
+        {{ 'shared.discussion' | translate }}
+      </a>
+    </p>
+  </article>
+
+  <article>
+    <h1><a name="separate">{{ 'separate.title' | translate }}</a></h1>
+
+    <p>{{ 'separate.body.first' | translate }}</p>
+    <div class='code-block'>
+      <p class="spec-title spec-wrong">{{ 'shared.bad_code' | translate }}</p>
+
+{% highlight ruby %}
+describe 'User' do
+  describe '#fiddle' do
+    it 'lets the user play their fiddle' do
+      user = User.create
+      fiddle = instance_double Fiddle
+      allow(Fiddle).to receive(:new).and_return(fiddle)
+      expect(user.fiddle).to eq("🎵")
+    end
+  end
+end
+{% endhighlight %}
+    </div>
+    <div class='code-block'>
+      <p class="spec-title spec-correct">{{ 'shared.good_code' | translate }}</p>
+
+{% highlight ruby %}
+describe 'User' do
+  subject(:user) { User.create }
+
+  describe '#fiddle' do
+    let(:fiddle) { instance_double Fiddle }
+    before { allow(Fiddle).to receive(:new).and_return(fiddle) }
+
+    it 'lets the user play their fiddle' do
+      expect(user.fiddle).to eq("🎵")
+    end
+  end
+end
+{% endhighlight %}
+    <p>{{ 'separate.body.second' | translate }}</p>
+    <div class="code-block">
+      <p class="spec-title spec-correct">{{ 'shared.good_code' | translate }}</p>
+
+{% highlight ruby %}
+let(:in_tune) { true }
+
+it { is_expected.to eq("🎵")
+
+context 'when the fiddle needs a tune up' do # this describes a variation
+  let(:in_tune { false } # this creates the variation
+
+  it { is_expected.to eq("😬")
+end
+{% endhighlight %}
+    </div>
+    <p>
+      <a href="https://github.com/andreareginato/betterspecs/issues/11">
         {{ 'shared.discussion' | translate }}
       </a>
     </p>


### PR DESCRIPTION
Hey thanks for considering my suggestion 😄 

I recently encountered a test suite that had many examples of the "bad" version of this rule. It was so difficult to understand what was changing between each test because they only used local variables inside the `it` blocks. Nearly every test looked the same except for one tiny difference. The worst of them had multiple expectations with mutations between each one. I was expecting something like this to already be part of the guide, but since it isn't I propose we add it.

I put it under "Create the data you need" as they are related. Each `describe` or `context` should do the minimum work possible to make the tests within it pass. I'm not 100% convinced it goes there. Here are some alternatives I also considered:

- It seems related to "Use context" but with more detail about how and why. I could consider merging the second half with that section if we like that better.
- It's also related to "Use subject" and "Use let and let!", but demonstrates how all these features can work together.
- Finally, its related to "Single expectation" since that guidline and this one both emphasize readability.

I'm not sure if using UTF emoji is ok, but I'm not married to the content of the examples. Feel free to suggest something different.

Full text:

# Separate Setup

Keep the body of tests focused on the actions under test. Move setup steps to a `before`, `let`, or `subject`.

## Bad
```ruby
describe 'User' do
  describe '#fiddle' do
    it 'fiddles with the user' do
      user = User.create
      fiddle = instance_double Fiddle
      allow(Fiddle).to receive(:new).and_return(fiddle)
      expect(user.fiddle).to eq(🎵)
    end
  end
end
```

## Good
```ruby
describe 'User' do
  subject(:user) { User.create }

  describe '#fiddle' do
    let(:fiddle) { instance_double Fiddle }
    before { allow(Fiddle).to receive(:new).and_return(fiddle) }

    it 'fiddles with the user' do
      expect(user.fiddle).to eq(🎵 )
    end
  end
end
```
This structure highlights what action is being tested, and makes it clear which parts are only necessary for setup. In this example we're communicating that all the tests describing a User will need <code>User.create</code>, but only tests of the <code>#fiddle</code> method need to setup a mock Fiddle.

Related to this, when a context describes a new variation, put the setup which creates that variation right below it.

## Good
```ruby
let(:fiddle) { instance_double Fiddle, in_tune?: in_tune }
let(:in_tune) { true }

it { is_expected.to eq(🎵 ) }

context "when the fiddle is out of tune" do # this describes a variation
  let(:in_tune) { false } # this creates the variation described above

  it { is_expected.to eq(😬 ) }
end
```