### PR TITLE
Fix links to http://myronmars.to blog

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -91,8 +91,8 @@ en:
         <a href='https://github.com/yujinakayama/transpec'>transpec</a> to \
         convert them to the new syntax. More about the new RSpec expectation \
         syntax can be found \
-        <a href='http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax'>here</a> \
-        and <a href='http://myronmars.to/n/dev-blog/2013/07/the-plan-for-rspec-3#what_about_the_old_expectationmock_syntax'>here</a>."
+        <a href='http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/'>here</a> \
+        and <a href='http://rspec.info/blog/2013/07/the-plan-for-rspec-3/#what_about_the_old_expectationmock_syntax'>here</a>."
   subject:
     title: Use subject
     body:
@@ -125,7 +125,7 @@ en:
         application flow."
       second: "Mocking makes your specs faster but they are difficult to use. \
         You need to understand them well to use them well. Read \
-        <a href='http://myronmars.to/n/dev-blog/2012/06/thoughts-on-mocking'>this article</a> \
+        <a href='https://web.archive.org/web/20220612005103/http://myronmars.to/n/dev-blog/2012/06/thoughts-on-mocking'>this article</a> \
         to learn more about mocks."
   data:
     title: Create only the data you need
@@ -184,7 +184,7 @@ en:
     body:
       first: "Do not use should when describing your tests. Use the third \
         person in the present tense. Even better start using the new \
-        <a href='http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax'>expectation</a> syntax."
+        <a href='http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/'>expectation</a> syntax."
       second: "See <a href='https://github.com/should-not/should_not'>the \
         should_not gem</a> for a way to enforce this in RSpec and \
         <a href='https://github.com/siyelo/should_clean'>the should_clean</a> \

--- a/_i18n/fr.yml
+++ b/_i18n/fr.yml
@@ -90,8 +90,8 @@ fr:
       fourth: "Sur un vieux project vous pouvez toujours utiliser \
         <a href='https://github.com/yujinakayama/transpec'>transpec</a> pour \
         les convertir dans la nouvelle syntaxe. Pour en savoir plus sur la nouvelle syntaxe \
-        <a href='http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax'>c'est ici</a> \
-        et <a href='http://myronmars.to/n/dev-blog/2013/07/the-plan-for-rspec-3#what_about_the_old_expectationmock_syntax'>ici</a>."
+        <a href='http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/'>c'est ici</a> \
+        et <a href='http://rspec.info/blog/2013/07/the-plan-for-rspec-3/#what_about_the_old_expectationmock_syntax'>ici</a>."
   subject:
     title: Utiliser «subject"
     body:
@@ -123,7 +123,7 @@ fr:
       second: "Utiliser des «mocks» rend vos spécifications plus rapides \
         mais elles sont plus difficiles à utiliser. Vous avez besoin de \
         les maîtriser pour bien les utiliser. Lire plus \
-        <a href='http://myronmars.to/n/dev-blog/2012/06/thoughts-on-mocking'>à propos</a>."
+        <a href='https://web.archive.org/web/20220612005103/http://myronmars.to/n/dev-blog/2012/06/thoughts-on-mocking'>à propos</a>."
   data:
     title: Créer seulement les données requises
     body: "Si vous avez déjà travaillé sur des projets de taille moyenne \
@@ -190,7 +190,7 @@ fr:
       first: "N'utiliser pas 'should' quand vous décrivez vos tests. \
         Utiliser la troisième personne au présent simple. Encore mieux \
         commencer à utiliser la nouvelle syntaxe \
-        <a href='http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax'>\
+        <a href='http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/'>\
         «should»</a>
 syntax."
       second: "Voir <a href='https://github.com/should-not/should_not'>\

--- a/_i18n/pt-BR.yml
+++ b/_i18n/pt-BR.yml
@@ -91,8 +91,8 @@ pt-BR:
       <a href='https://github.com/yujinakayama/transpec'>transpec</a> para 
       convertê-los para a nova sintaxe. Leia mais sobre a nova sintaxe de 
       expectativa do RSpec 
-      <a href='http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax'>aqui</a> 
-      e <a href='http://myronmars.to/n/dev-blog/2013/07/the-plan-for-rspec-3#what_about_the_old_expectationmock_syntax'>aqui</a>."
+      <a href='http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/'>aqui</a> 
+      e <a href='http://rspec.info/blog/2013/07/the-plan-for-rspec-3/#what_about_the_old_expectationmock_syntax'>aqui</a>."
   subject:
     title: Use subject
     body:
@@ -124,7 +124,7 @@ pt-BR:
         atualizar o fluxo da sua aplicação."
       second: "Utilizar mocks torna seus specs mais rápidos, mas eles são 
         difíceis de usar. Você precisa entendê-los bem para usá-los bem. Leia 
-        mais <a href='http://myronmars.to/n/dev-blog/2012/06/thoughts-on-mocking'>sobre</a>."
+        mais <a href='https://web.archive.org/web/20220612005103/http://myronmars.to/n/dev-blog/2012/06/thoughts-on-mocking'>sobre</a>."
   data:
     title: Crie apenas os dados necessários
     body: "Se você já trabalhou em um projeto de médio porte (mas também em 
@@ -185,7 +185,7 @@ pt-BR:
     body:
       first: "Não use should ao decrever seus testes. Use a terceira pessoa do 
       presente. Melhor ainda, comece a utilizar a nova 
-      <a href='http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax'>sintaxe de expectativa</a>."
+      <a href='http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/'>sintaxe de expectativa</a>."
       second: "Veja a gem <a href='https://github.com/should-not/should_not'>should_not</a> 
         como uma forma de reforçar isto no RSpec e a gem 
         <a href='https://github.com/siyelo/should_clean'>should_clean</a> para 


### PR DESCRIPTION
The http://myronmars.to blog is linked to in a few places. This blog was running on a Heroku instance which is now down. This pull request updates the links to the articles to either point to an archived version or the blog where the author has republished the article.

Github Issue: https://github.com/betterspecs/betterspecs/issues/241